### PR TITLE
add Organisations to schema

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,0 +1,3 @@
+class Organisation < ApplicationRecord
+  has_many :users, dependent: :destroy
+end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,6 +4,7 @@ class Project < ApplicationRecord
   # has_many :users, through: :project_users, as: :clients
   has_many :deliverables, dependent: :destroy
   has_many :drafts, through: :deliverables
+  has_and_belongs_to_many :users, join_table: :project_users
 
   # scope :filter_status, ->status { where("status ILIKE ?", status) }
   scope :filter_name, ->name { where("name ILIKE ?", "%#{name}%")}

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,6 +5,7 @@ class User < ApplicationRecord
         :recoverable, :rememberable, :validatable
 
   belongs_to :organisation
+  has_and_belongs_to_many :projects, join_table: :project_users
 
   has_many :projects, dependent: :destroy
   has_many :deliverables, through: :projects

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ApplicationRecord
   belongs_to :organisation
   has_and_belongs_to_many :projects, join_table: :project_users
 
-  has_many :projects, dependent: :destroy
+  has_many :projects, as: :owner, dependent: :destroy
   has_many :deliverables, through: :projects
   has_many :comments, dependent: :destroy
   has_many :notifications, as: :recipient, dependent: :destroy

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,8 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
         :recoverable, :rememberable, :validatable
 
+  belongs_to :organisation
+
   has_many :projects, dependent: :destroy
   has_many :deliverables, through: :projects
   has_many :comments, dependent: :destroy

--- a/db/migrate/20211230013908_create_organisations.rb
+++ b/db/migrate/20211230013908_create_organisations.rb
@@ -1,0 +1,8 @@
+class CreateOrganisations < ActiveRecord::Migration[6.1]
+  def change
+    create_table :organisations do |t|
+      t.string :name
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211230014341_add_organisation_to_user.rb
+++ b/db/migrate/20211230014341_add_organisation_to_user.rb
@@ -1,0 +1,5 @@
+class AddOrganisationToUser < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :users, :organisation, foreign_key: true
+  end
+end

--- a/db/migrate/20211230014923_change_brand_reference_in_projects.rb
+++ b/db/migrate/20211230014923_change_brand_reference_in_projects.rb
@@ -1,0 +1,6 @@
+class ChangeBrandReferenceInProjects < ActiveRecord::Migration[6.1]
+  def change
+    remove_reference :projects, :brand, foreign_key: true
+    add_reference :projects, :client, foreign_key: { to_table: :organisations }
+  end
+end

--- a/test/models/organisation_test.rb
+++ b/test/models/organisation_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class OrganisationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## Why
currently, project is tied to one creator and one brand. Made changes so that multiple (>2) users can work on one project and multiple users from the same organisation can work on the same project.

## What

Created Organisations Table
Created Organisaations Model
Changed References between organisations, users and projects
Creates associations between organisations, users and projects