### PR TITLE
fixed migration issue

### DIFF
--- a/db/migrate/20211230014923_change_brand_reference_in_projects.rb
+++ b/db/migrate/20211230014923_change_brand_reference_in_projects.rb
@@ -1,6 +1,6 @@
 class ChangeBrandReferenceInProjects < ActiveRecord::Migration[6.1]
   def change
-    remove_reference :projects, :brand, foreign_key: true
+    remove_column :projects, :brand_id, :integer
     add_reference :projects, :client, foreign_key: { to_table: :organisations }
   end
 end


### PR DESCRIPTION
## Why
brand reference from projects table to be removed as "brand_id"
## What

changed remove_references to remove_column, under "brand_id" instead of "brand"