### PR TITLE
remove account type

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     # For additional fields in app/views/devise/registrations/new.html.erb
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:username, :account_type])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:username])
   end
 
   def default_url_options

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,5 @@ class User < ApplicationRecord
   has_many :paid_projects, class_name: "Project", foreign_key: "brand_id", dependent: :destroy
 
   validates :username, presence: true, uniqueness: true
-  validates :account_type, presence: true
 
 end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -11,10 +11,6 @@
                 required: true,
                 autofocus: true,
                 input_html: { class: "form-control-sm" }%>
-    <%= f.input :account_type,
-                required: true,
-                autofocus: true,
-                as: :radio_buttons, collection: [['Creator'], ['Brand']] %>
     <%= f.input :password,
                 required: true,
                 hint: ("#{@minimum_password_length} characters minimum" if @minimum_password_length),

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_30_014923) do
+ActiveRecord::Schema.define(version: 2021_12_30_083634) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -127,7 +127,6 @@ ActiveRecord::Schema.define(version: 2021_12_30_014923) do
     t.datetime "remember_created_at"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.string "account_type"
     t.string "first_name"
     t.string "last_name"
     t.string "username"


### PR DESCRIPTION
## Why

Column - account type is removed from schema.

## What

- Removed account type field from sign up form
- Removed account type validation from user.rb and application controller
