### PR TITLE
added role column to project_users

### DIFF
--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,13 +4,13 @@ class Project < ApplicationRecord
   # has_many :users, through: :project_users, as: :clients
   has_many :deliverables, dependent: :destroy
   has_many :drafts, through: :deliverables
-  has_and_belongs_to_many :users, join_table: :project_users
+  has_many :users, through: :project_users
 
   # scope :filter_status, ->status { where("status ILIKE ?", status) }
   scope :filter_name, ->name { where("name ILIKE ?", "%#{name}%")}
   scope :status, ->status { where("status ILIKE ?", "%#{status}%")}
 
   def brand
-  Organisation.find(self.client_id)
+    Organisation.find(self.client_id)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,7 +5,7 @@ class User < ApplicationRecord
         :recoverable, :rememberable, :validatable
 
   belongs_to :organisation
-  has_and_belongs_to_many :projects, join_table: :project_users
+  has_many :projects, through: :project_users
 
   has_many :projects, dependent: :destroy
   has_many :deliverables, through: :projects

--- a/db/migrate/20220105124256_add_roles_to_project_users.rb
+++ b/db/migrate/20220105124256_add_roles_to_project_users.rb
@@ -1,0 +1,5 @@
+class AddRolesToProjectUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :project_users, :role, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_30_083634) do
+ActiveRecord::Schema.define(version: 2022_01_05_124256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -73,6 +73,7 @@ ActiveRecord::Schema.define(version: 2021_12_30_083634) do
     t.bigint "project_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "role"
     t.index ["project_id"], name: "index_project_users_on_project_id"
     t.index ["user_id"], name: "index_project_users_on_user_id"
   end


### PR DESCRIPTION
## Why

added role column to project_users table to enable authorization and permissions depending on user

## What

- added role column to project_users
- changed 'has_many_and_belongs_to' in users and projects table to 'has_many __, through: project_users' as we will be working with the project_users table
