### PR TITLE
added delete button for notifications

### DIFF
--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -32,6 +32,7 @@
   }
   // Each notification card
   .notification {
+    position: relative;
     color: black;
     padding: 0px 5px;
     font-size: 14px;

--- a/app/assets/stylesheets/components/icon.scss
+++ b/app/assets/stylesheets/components/icon.scss
@@ -13,3 +13,12 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 }
+
+.notification-trash-icon {
+  position: absolute;
+  top: 5px;
+  right: 5px;
+  background: $dark-grey;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+}

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -19,4 +19,10 @@ class NotificationsController < ApplicationController
     @notification = Notification.find(params[:id])
     @notification.mark_as_read!
   end
+
+  def destroy
+    @notification = Notification.find(params[:id])
+    @notification.destroy
+    format.html { redirect_to root_path }
+  end
 end

--- a/app/javascript/controllers/mark_read_controller.js
+++ b/app/javascript/controllers/mark_read_controller.js
@@ -3,7 +3,7 @@ import { csrfToken } from "@rails/ujs";
 import { Controller } from "stimulus"
 
 export default class extends Controller {
-  static targets = ["notif"]
+  static targets = ["notif", "trash"]
 
   markAsRead(){
     const notif_id = this.notifTarget.dataset.value
@@ -20,4 +20,19 @@ export default class extends Controller {
       });
   }
 
+  destroy(e) {
+    e.preventDefault()
+
+    const destroy_notif_id = this.trashTarget.dataset.value
+    const path = `/notifications/${destroy_notif_id}`
+
+    fetch(path, {
+      method: 'DELETE',
+      headers: { 'X-CSRF-Token': csrfToken() }
+    }).then(response => response.html())
+      .then((data) => {
+        console.log(data);
+        console.log("deleted notif");
+      });
+  }
 }

--- a/app/views/notifications/_notification.html.erb
+++ b/app/views/notifications/_notification.html.erb
@@ -6,7 +6,7 @@
         <img src="<%=notif.to_notification.user.profile_pic%>" alt="avatar" class="avatar">
       </div>
       <div>
-        <p id="author"><%= notif.to_notification.user.first_name %></p>
+        <p id="author"><%= notif.to_notification.user.first_name.length > 10 ? notif.to_notification.user.first_name[0..10] + '...' : notif.to_notification.user.first_name %></p>
         <p>
           <% if (Time.now - notif.created_at)< 1.hour%>
             <%= distance_of_time_in_words_to_now(notif.created_at)%> ago
@@ -15,6 +15,7 @@
           <% end %>
         </p>
       </div>
+      <i class="fas fa-trash notification-trash-icon" data-value="<%=notif.id%>" data-mark-read-target="trash" data-action="click->mark-read#destroy"></i>
     </div>
     <div>
       <p><%= notif.to_notification.message %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,7 @@ Rails.application.routes.draw do
 
   get '/notifications', to: "notifications#index"
 
-  resources :notifications, only: [:update]
+  resources :notifications, only: [:update, :destroy]
 
   resources :projects do
     resources :deliverables,only: [:new, :create]


### PR DESCRIPTION
## Why

previously, could only remove notifications by clicking on it which will redirect us to the drafts show page
now, able to delete notifications directly by clicking on the trash icon next to notification

## What

- added trash icon to delete notification
- added destroy route for notification
- added logic to shorten notification author's name so as to not overlap with trash icon
