### PR TITLE
user unable to view projects that are not his

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -27,8 +27,12 @@ class ProjectsController < ApplicationController
       redirect_to new_user_session_path if !(user_signed_in?)
     end
 
-    @deliverables = @project.deliverables.order(:due_date)
-    @deliverables_by_date_hash = @deliverables.group_by { |deliverable| deliverable.due_date}
+    if @project.user == current_user || @project.users == current_user
+      @deliverables = @project.deliverables.order(:due_date)
+      @deliverables_by_date_hash = @deliverables.group_by { |deliverable| deliverable.due_date}
+    else
+      redirect_back(fallback_location: root_path)
+    end
   end
 
   def sign_up


### PR DESCRIPTION
## Why

users are able to view projects which he is neither the owner nor collaborator by changing the project id directly in the url

## What

- added logic such that user can only view projects where he is the owner or collaborator
- if user keys in other project id into the url where the project is not his, user will be redirected back to home page
