### PR TITLE
only admins can change roles

### DIFF
--- a/app/views/projects/_share.html.erb
+++ b/app/views/projects/_share.html.erb
@@ -43,8 +43,8 @@
         </div>
       </div>
       <div class="role-position-right">
-        <select name="role" id="role">
-          <% role = ProjectUser.find_by(user_id: collaborator.id).role %>
+        <% role = ProjectUser.find_by(user_id: collaborator.id).role %>
+        <select name="role" id="role" <%= role.name == 'admin' ? "" : disabled="disabled" %>>
           <option value="admin" <% role == 'admin' ? selected : "" %>>Admin</option>
           <option value="collaborator" <% role == 'collaborator' ? selected : "" %>>Collaborator</option>
         </select>


### PR DESCRIPTION
## Why

only admins are able to change the roles of other collaborators

## What

disabled the dropdown for non-admins
