### PR TITLE
removed poppler from gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -197,7 +197,6 @@ GEM
     pg (1.2.3)
     pkg-config (1.4.6)
     popper_js (1.16.0)
-    poppler (3.4.9)
       cairo-gobject (= 3.4.9)
       gio2 (= 3.4.9)
     pry (0.13.1)
@@ -350,7 +349,6 @@ DEPENDENCIES
   listen (~> 3.3)
   noticed (~> 1.5, >= 1.5.5)
   pg (~> 1.1)
-  poppler (~> 3.0, >= 3.0.7)
   pry-byebug
   pry-rails
   puma (~> 5.0)


### PR DESCRIPTION
## Why
removed poppler from gemfile.lock to push to heroku

## What
removed poppler from gemfile.lock
