### PR TITLE
resolving bundler upgrade issue

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,10 +182,14 @@ GEM
     method_source (1.0.0)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     native-package-installer (1.1.1)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -327,6 +331,7 @@ GEM
     zeitwerk (2.5.1)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
## Why

bundler upgrade issue may be causing errors while pushing to heroku

## What

$ bundle lock --add-platform ruby
$ bundle lock --add-platform x86_64-linux
$ bundle install
